### PR TITLE
Add props id , name 

### DIFF
--- a/src/components/TypeAhead.vue
+++ b/src/components/TypeAhead.vue
@@ -4,6 +4,8 @@
                :placeholder="placeholder"
                autocomplete="do-not-use"
                v-model="query"
+               :id="id"
+               :name="name"
                @keydown.down="down"
                @keydown.up="up"
                @keydown.enter.prevent="hit"
@@ -38,6 +40,16 @@
   export default{
     name: 'TypeAhead',
     props: {
+      id: {
+        required: false,
+        type: String,
+        default: ''
+      },
+      name: {
+        required: false,
+        type: String,
+        default: ''
+      },
       selectFirst: {
         // 是否选择第一个选项
         required: false,


### PR DESCRIPTION
Somehow the original  `vue2-bootstrap4-typeahead` has a lake of id and name properties, since the original https://github.com/pespantelis/vue-typeahead is no longer maintained, I add it here